### PR TITLE
Chapter 7 DecisionTree example used normalized data

### DIFF
--- a/Chapter07/Chapter 7.ipynb
+++ b/Chapter07/Chapter 7.ipynb
@@ -627,7 +627,9 @@
     "\n",
     "classTree = DecisionTreeClassifier()\n",
     "classTree.fit(Xs, y)\n",
-    "\n",
+    "newApplicant = pd.DataFrame({'income': applicant_df.loc[20].income, \n",
+    "                             'score': applicant_df.iloc[20].score},\n",
+    "                             index=[20])\n",
     "predict_y = classTree.predict(newApplicant)\n",
     "print(predict_y)"
    ]


### PR DESCRIPTION
The DecisionTree example in 'Chapter 7.ipynb' was not running with scikit-learn 1.2.1 and with Scikit-learn 1.1.1 was throwing a warning. The message included:  "The feature names should match those that were passed during fit." and was referencing the normalized data.

After some digging, it turns out that newApplicant was changed for KNN example and not reverted to the original data for the DecisionTree example. This code creates a newApplicant with non-normalized values and now runs without throwing errors. I tried to stay close to the style of the code in the KNN example.